### PR TITLE
[IA-4945] Implement validation on chart name and chart version

### DIFF
--- a/service/src/main/java/bio/terra/appmanager/controller/AdminController.java
+++ b/service/src/main/java/bio/terra/appmanager/controller/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
+// TODO: advice?
 public class AdminController implements AdminApi {
   private final ChartService chartService;
 

--- a/service/src/main/java/bio/terra/appmanager/controller/AdminController.java
+++ b/service/src/main/java/bio/terra/appmanager/controller/AdminController.java
@@ -9,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-// TODO: advice?
 public class AdminController implements AdminApi {
   private final ChartService chartService;
 

--- a/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
@@ -2,8 +2,12 @@ package bio.terra.appmanager.controller;
 
 import bio.terra.appmanager.api.model.ErrorReport;
 import bio.terra.common.exception.AbstractGlobalExceptionHandler;
+import bio.terra.common.exception.InconsistentFieldsException;
+import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -12,5 +16,14 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
   @Override
   public ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value());
+  }
+
+  // TODO: test this on running app?
+  @ExceptionHandler(InconsistentFieldsException.class)
+  public ResponseEntity<ErrorReport> constraintViolationExceptionHandler(
+      ConstraintViolationException ex) {
+    ErrorReport errorReport =
+        new ErrorReport().message(ex.getMessage()).statusCode(HttpStatus.BAD_REQUEST.value());
+    return new ResponseEntity<>(errorReport, HttpStatus.BAD_REQUEST);
   }
 }

--- a/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
 
   @Override
   public ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
+    System.out.println("in error report " + statusCode.toString());
     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value());
   }
 
@@ -22,6 +23,7 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
   @ExceptionHandler(InconsistentFieldsException.class)
   public ResponseEntity<ErrorReport> constraintViolationExceptionHandler(
       ConstraintViolationException ex) {
+    System.out.println("in handler");
     ErrorReport errorReport =
         new ErrorReport().message(ex.getMessage()).statusCode(HttpStatus.BAD_REQUEST.value());
     return new ResponseEntity<>(errorReport, HttpStatus.BAD_REQUEST);

--- a/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/appmanager/controller/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package bio.terra.appmanager.controller;
 import bio.terra.appmanager.api.model.ErrorReport;
 import bio.terra.common.exception.AbstractGlobalExceptionHandler;
 import bio.terra.common.exception.InconsistentFieldsException;
-import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,15 +14,12 @@ public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<Error
 
   @Override
   public ErrorReport generateErrorReport(Throwable ex, HttpStatus statusCode, List<String> causes) {
-    System.out.println("in error report " + statusCode.toString());
     return new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value());
   }
 
-  // TODO: test this on running app?
   @ExceptionHandler(InconsistentFieldsException.class)
   public ResponseEntity<ErrorReport> constraintViolationExceptionHandler(
-      ConstraintViolationException ex) {
-    System.out.println("in handler");
+      InconsistentFieldsException ex) {
     ErrorReport errorReport =
         new ErrorReport().message(ex.getMessage()).statusCode(HttpStatus.BAD_REQUEST.value());
     return new ResponseEntity<>(errorReport, HttpStatus.BAD_REQUEST);

--- a/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
+++ b/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
@@ -15,12 +15,16 @@ public record ChartVersion(
   public ChartVersion {
     if (!isChartNameValid(chartName)) {
       throw new InconsistentFieldsException(
-          "Chart name is invalid, must follow chart name conventions: https://helm.sh/docs/chart_best_practices/conventions/#chart-names. Regex used: "
+          "Chart name "
+              + chartName
+              + " is invalid, must follow chart name conventions: https://helm.sh/docs/chart_best_practices/conventions/#chart-names. Regex used: "
               + chartNameRegex);
     }
     if (!isChartVersionValid(chartVersion)) {
       throw new InconsistentFieldsException(
-          "Chart version is invalid, must follow chart version conventions: https://helm.sh/docs/chart_best_practices/values/. Value must be camel case, the first letter must be lowercase and value must have letters only. Regex used: '^[a-z][a-z]*(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$'");
+          "Chart version "
+              + chartVersion
+              + " is invalid, must follow chart version conventions: https://helm.sh/docs/chart_best_practices/values/. Value must be camel case, the first letter must be lowercase and value must have letters only. Regex used: '^[a-z][a-z]*(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$'");
     }
   }
 
@@ -30,7 +34,8 @@ public record ChartVersion(
   static final String chartNameRegex = "^[a-z0-9-]{1,25}$";
   // Must follow chart value conventions:
   // https://helm.sh/docs/chart_best_practices/values/#naming-conventions
-  // Camel case, requiring the first letter to be lowercase with no numeric characters. Letters only.
+  // Camel case, requiring the first letter to be lowercase with no numeric characters. Letters
+  // only.
   // See regex test cases: https://regex101.com/r/4h7A1I/8
   static final String chartValueRegex = "^[a-z][a-z]*(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$";
 

--- a/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
+++ b/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
@@ -38,8 +38,8 @@ public record ChartVersion(
   // https://helm.sh/docs/chart_best_practices/values/#naming-conventions
   // Camel case, requiring the first letter to be lowercase with no numeric characters. Letters
   // only. Additionally we impose 1-25 character limit
-  // See regex test cases: https://regex101.com/r/4h7A1I/8
-  static final String chartValueRegex = "^[a-z]+(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$";
+  // See regex test cases: https://regex101.com/r/nz2Ccj/1
+  static final String chartValueRegex = "^[a-z]+(([A-Z][a-z]+)*[A-Z]?)$";
   static final Pattern chartVersionPattern = Pattern.compile(chartValueRegex);
 
   public static boolean isChartNameValid(String chartName) {

--- a/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
+++ b/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
@@ -24,7 +24,8 @@ public record ChartVersion(
       throw new InconsistentFieldsException(
           "Chart version "
               + chartVersion
-              + " is invalid, must follow chart version conventions: https://helm.sh/docs/chart_best_practices/values/. Value must be camel case, the first letter must be lowercase and value must have letters only. Regex used: '^[a-z][a-z]*(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$'");
+              + " is invalid, must follow chart version conventions: https://helm.sh/docs/chart_best_practices/values/. Value must be camel case, the first letter must be lowercase and value must have letters only. Regex used: "
+              + chartValueRegex);
     }
   }
 
@@ -32,20 +33,20 @@ public record ChartVersion(
   // https://helm.sh/docs/chart_best_practices/conventions/#chart-names
   // Alphanumeric lowercase with dashes allowed, additionally we impose 1-25 character limit
   static final String chartNameRegex = "^[a-z0-9-]{1,25}$";
+  static final Pattern chartNamePattern = Pattern.compile(chartNameRegex);
   // Must follow chart value conventions:
   // https://helm.sh/docs/chart_best_practices/values/#naming-conventions
   // Camel case, requiring the first letter to be lowercase with no numeric characters. Letters
   // only. Additionally we impose 1-25 character limit
   // See regex test cases: https://regex101.com/r/4h7A1I/8
   static final String chartValueRegex = "^[a-z]+(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$";
+  static final Pattern chartVersionPattern = Pattern.compile(chartValueRegex);
 
   public static boolean isChartNameValid(String chartName) {
-    Pattern chartNamePattern = Pattern.compile(chartNameRegex);
     return chartNamePattern.matcher(chartName).matches();
   }
 
   public static boolean isChartVersionValid(String chartVersion) {
-    Pattern chartVersionPattern = Pattern.compile(chartValueRegex);
     return chartVersionPattern.matcher(chartVersion).matches() && chartVersion.length() < 25;
   }
 

--- a/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
+++ b/service/src/main/java/bio/terra/appmanager/model/ChartVersion.java
@@ -35,9 +35,9 @@ public record ChartVersion(
   // Must follow chart value conventions:
   // https://helm.sh/docs/chart_best_practices/values/#naming-conventions
   // Camel case, requiring the first letter to be lowercase with no numeric characters. Letters
-  // only.
+  // only. Additionally we impose 1-25 character limit
   // See regex test cases: https://regex101.com/r/4h7A1I/8
-  static final String chartValueRegex = "^[a-z][a-z]*(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$";
+  static final String chartValueRegex = "^[a-z]+(([A-Z][a-z]+)*[A-Z]?|([a-z]+[A-Z])*|[A-Z])$";
 
   public static boolean isChartNameValid(String chartName) {
     Pattern chartNamePattern = Pattern.compile(chartNameRegex);
@@ -45,8 +45,8 @@ public record ChartVersion(
   }
 
   public static boolean isChartVersionValid(String chartVersion) {
-    Pattern chartNamePattern = Pattern.compile(chartValueRegex);
-    return chartNamePattern.matcher(chartVersion).matches();
+    Pattern chartVersionPattern = Pattern.compile(chartValueRegex);
+    return chartVersionPattern.matcher(chartVersion).matches() && chartVersion.length() < 25;
   }
 
   public ChartVersion(String chartName, String chartVersion) {

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -54,8 +54,7 @@ paths:
         '201':
           description: ChartVersion(s) have been successfully created
         '400':
-          description: Bad request - invalid ChartVersion(s) provided
-#          $ref: '#/components/responses/ServerError'
+          $ref: '#/components/responses/ServerError'
         '403':
           description: Request did not come from an admin
         '500':

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -55,6 +55,7 @@ paths:
           description: ChartVersion(s) have been successfully created
         '400':
           description: Bad request - invalid ChartVersion(s) provided
+#          $ref: '#/components/responses/ServerError'
         '403':
           description: Request did not come from an admin
         '500':

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -54,7 +54,7 @@ paths:
         '201':
           description: ChartVersion(s) have been successfully created
         '400':
-          $ref: '#/components/responses/ServerError'
+          $ref: '#/components/responses/BadRequest'
         '403':
           description: Request did not come from an admin
         '500':
@@ -132,6 +132,7 @@ components:
           type: string
         statusCode:
           type: integer
+
 
     SystemStatus:
       required: [ ok, systems ]

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -1,7 +1,6 @@
 package bio.terra.appmanager.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -14,7 +13,6 @@ import bio.terra.appmanager.api.model.ChartArray;
 import bio.terra.appmanager.controller.AdminController;
 import bio.terra.appmanager.controller.GlobalExceptionHandler;
 import bio.terra.appmanager.service.ChartService;
-import bio.terra.common.exception.InconsistentFieldsException;
 import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -85,18 +83,11 @@ class AdminControllerTest {
         capture_chartVersions.getValue().get(0), chartName, chartVersion, null, null, null);
   }
 
-  // TODO: it might be impossible to inject mockMvcc with GlobalExceptionHandler and verify the
-  // badrequest response
-  // See https://github.com/spring-projects/spring-boot/issues/7321
   @Test
   void testInvalidChartVersionPost() throws Exception {
     String chartName = "chart-name-here";
     String chartVersion = "invalid-chart-version$";
 
-    //    Exception ex =
-    //        assertThrows(
-    //            jakarta.servlet.ServletException.class,
-    //            () ->
     mockMvc
         .perform(
             post("/api/admin/v1/charts/versions")
@@ -111,7 +102,6 @@ class AdminControllerTest {
                         + "\""
                         + "}]"))
         .andExpect(status().isBadRequest());
-    //    assertEquals(InconsistentFieldsException.class, ex.getCause().getClass());
   }
 
   @Test
@@ -119,23 +109,20 @@ class AdminControllerTest {
     String chartName = "invalidChartName$";
     String chartVersion = "validChartVersion";
 
-    Exception ex =
-        assertThrows(
-            jakarta.servlet.ServletException.class,
-            () ->
-                mockMvc.perform(
-                    post("/api/admin/v1/charts/versions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(
-                            "[{"
-                                + "\"chartName\": \""
-                                + chartName
-                                + "\","
-                                + "\"chartVersion\": \""
-                                + chartVersion
-                                + "\""
-                                + "}]")));
-    assertEquals(InconsistentFieldsException.class, ex.getCause().getClass());
+    mockMvc
+        .perform(
+            post("/api/admin/v1/charts/versions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "[{"
+                        + "\"chartName\": \""
+                        + chartName
+                        + "\","
+                        + "\"chartVersion\": \""
+                        + chartVersion
+                        + "\""
+                        + "}]"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -44,7 +44,7 @@ class AdminControllerTest {
   private AutoCloseable closeable;
 
   @BeforeEach
-  public void open() {
+  public void setup() {
     closeable = MockitoAnnotations.openMocks(this);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -52,6 +52,14 @@ class AdminControllerTest {
   }
 
   @Test
+  void testControllerCreate_inValid() throws Exception {
+    String validChartName = "valid-chart-name@@#_L";
+    String invalidChartVersion = "invalid-chart-versionQ$^";
+    bio.terra.appmanager.model.ChartVersion chartVersion =
+        new bio.terra.appmanager.model.ChartVersion(validChartName, invalidChartVersion);
+  }
+
+  @Test
   void testCreate_204() throws Exception {
     String chartName = "chart-name-here";
     String chartVersion = "chart-version-here";

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -84,7 +84,7 @@ class AdminControllerTest {
   }
 
   @Test
-  void testInvalidChartVersionPost() throws Exception {
+  void testCreate_invalidChartVersion() throws Exception {
     String chartName = "chart-name-here";
     String chartVersion = "invalid-chart-version$";
 
@@ -105,7 +105,7 @@ class AdminControllerTest {
   }
 
   @Test
-  void testInvalidChartNamePost() throws Exception {
+  void testCreate_invalidChartName() throws Exception {
     String chartName = "invalidChartName$";
     String chartVersion = "validChartVersion";
 

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -199,7 +199,7 @@ class AdminControllerTest {
   @Test
   void testGet_ChartVersionModelToApi() {
     String chartName = "chart-name-here";
-    String chartVersion = "chart-version";
+    String chartVersion = "chartVersion";
     bio.terra.appmanager.model.ChartVersion chart =
         new bio.terra.appmanager.model.ChartVersion(chartName, chartVersion);
     chart = chart.activate(new Date()).inactivate(new Date());

--- a/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
+++ b/service/src/test/java/bio/terra/appmanager/api/AdminControllerTest.java
@@ -93,23 +93,25 @@ class AdminControllerTest {
     String chartName = "chart-name-here";
     String chartVersion = "invalid-chart-version$";
 
-    Exception ex =
-        assertThrows(
-            jakarta.servlet.ServletException.class,
-            () ->
-                mockMvc.perform(
-                    post("/api/admin/v1/charts/versions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(
-                            "[{"
-                                + "\"chartName\": \""
-                                + chartName
-                                + "\","
-                                + "\"chartVersion\": \""
-                                + chartVersion
-                                + "\""
-                                + "}]")));
-    assertEquals(InconsistentFieldsException.class, ex.getCause().getClass());
+    //    Exception ex =
+    //        assertThrows(
+    //            jakarta.servlet.ServletException.class,
+    //            () ->
+    mockMvc
+        .perform(
+            post("/api/admin/v1/charts/versions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "[{"
+                        + "\"chartName\": \""
+                        + chartName
+                        + "\","
+                        + "\"chartVersion\": \""
+                        + chartVersion
+                        + "\""
+                        + "}]"))
+        .andExpect(status().isBadRequest());
+    //    assertEquals(InconsistentFieldsException.class, ex.getCause().getClass());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/appmanager/dao/ChartVersionDaoTest.java
+++ b/service/src/test/java/bio/terra/appmanager/dao/ChartVersionDaoTest.java
@@ -17,7 +17,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testSingleVersionUpsert() {
     String chartName = "chart-name-here";
-    String chartVersion = "chart-version-here";
+    String chartVersion = "chartVersionHere";
     ChartVersion version = new ChartVersion(chartName, chartVersion);
 
     versionDao.upsert(version);
@@ -36,7 +36,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
     String chartVersion1 = "chart-name-here";
     ChartVersion version1 = new ChartVersion(chartName, chartVersion1);
 
-    String chartVersion2 = "chart-version-here-too";
+    String chartVersion2 = "chartVersionHereToo";
     ChartVersion version2 = new ChartVersion(chartName, chartVersion2);
 
     versionDao.upsert(version1);
@@ -58,20 +58,20 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testMultiNameGet() {
     String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
-    String chartVersion1_2 = "chart-version-here-too";
+    String chartVersion1_1 = "chartVersionHereOne";
+    String chartVersion1_2 = "chartVersionHereToo";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
     ChartVersion version1_2 = new ChartVersion(chartName1, chartVersion1_2);
 
-    String chartName2 = "chart-version-here-too";
-    String chartVersion2_1 = "chart-version-here-3";
-    String chartVersion2_2 = "chart-version-here-four";
+    String chartName2 = "chart-name-here-too";
+    String chartVersion2_1 = "chartVersionHereThree";
+    String chartVersion2_2 = "chartVersionHereFour";
     ChartVersion version2_1 = new ChartVersion(chartName2, chartVersion2_1);
     ChartVersion version2_2 = new ChartVersion(chartName2, chartVersion2_2);
 
-    String chartName3 = "chart-version-here-again";
-    String chartVersion3_1 = "chart-version-here-5";
-    String chartVersion3_2 = "chart-version-here-six";
+    String chartName3 = "chartVersionHereAgain";
+    String chartVersion3_1 = "chartVersionHereFive";
+    String chartVersion3_2 = "chartVersionHereSix";
     ChartVersion version3_1 = new ChartVersion(chartName3, chartVersion3_1);
     ChartVersion version3_2 = new ChartVersion(chartName3, chartVersion3_2);
 
@@ -101,20 +101,20 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testGetAll() {
     String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
-    String chartVersion1_2 = "chart-version-here-too";
+    String chartVersion1_1 = "chartVersionHereOne";
+    String chartVersion1_2 = "chartVersionHereToo";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
     ChartVersion version1_2 = new ChartVersion(chartName1, chartVersion1_2);
 
-    String chartName2 = "chart-version-here-too";
-    String chartVersion2_1 = "chart-version-here-3";
-    String chartVersion2_2 = "chart-version-here-four";
+    String chartName2 = "chart-name-here-too";
+    String chartVersion2_1 = "chartVersionHereThree";
+    String chartVersion2_2 = "chartVersionHereFour";
     ChartVersion version2_1 = new ChartVersion(chartName2, chartVersion2_1);
     ChartVersion version2_2 = new ChartVersion(chartName2, chartVersion2_2);
 
-    String chartName3 = "chart-version-here-again";
-    String chartVersion3_1 = "chart-version-here-5";
-    String chartVersion3_2 = "chart-version-here-six";
+    String chartName3 = "chart-name-here-again";
+    String chartVersion3_1 = "chartVersionHereFive";
+    String chartVersion3_2 = "chartVersionHereSix";
     ChartVersion version3_1 = new ChartVersion(chartName3, chartVersion3_1);
     ChartVersion version3_2 = new ChartVersion(chartName3, chartVersion3_2);
 
@@ -132,7 +132,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testDelete() {
     String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
+    String chartVersion1_1 = "chartVersionHere";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
 
     versionDao.upsert(version1_1);
@@ -147,7 +147,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testDelete_noNames() {
     final String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
+    String chartVersion1_1 = "chartVersionHere";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
 
     versionDao.upsert(version1_1);
@@ -163,20 +163,20 @@ class ChartVersionDaoTest extends BaseDaoTest {
   @Test
   void testMultiDelete() {
     final String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
-    String chartVersion1_2 = "chart-version-here-too";
+    String chartVersion1_1 = "chartVersionHere";
+    String chartVersion1_2 = "chartVersionHereToo";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
     ChartVersion version1_2 = new ChartVersion(chartName1, chartVersion1_2);
 
-    final String chartName2 = "chart-version-here-too";
-    String chartVersion2_1 = "chart-version-here-3";
-    String chartVersion2_2 = "chart-version-here-four";
+    final String chartName2 = "chart-name-here-too";
+    String chartVersion2_1 = "chartVersionHereThree";
+    String chartVersion2_2 = "chartVersionHereFour";
     ChartVersion version2_1 = new ChartVersion(chartName2, chartVersion2_1);
     ChartVersion version2_2 = new ChartVersion(chartName2, chartVersion2_2);
 
-    final String chartName3 = "chart-version-here-again";
-    String chartVersion3_1 = "chart-version-here-5";
-    String chartVersion3_2 = "chart-version-here-six";
+    final String chartName3 = "chart-version-name-again";
+    String chartVersion3_1 = "chartVersionHereFive";
+    String chartVersion3_2 = "chartVersionHereSix";
     ChartVersion version3_1 = new ChartVersion(chartName3, chartVersion3_1);
     ChartVersion version3_2 = new ChartVersion(chartName3, chartVersion3_2);
 

--- a/service/src/test/java/bio/terra/appmanager/dao/ChartVersionDaoTest.java
+++ b/service/src/test/java/bio/terra/appmanager/dao/ChartVersionDaoTest.java
@@ -33,7 +33,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
   void testMultiVersionUpsert() {
     String chartName = "chart-name-here";
 
-    String chartVersion1 = "chart-name-here";
+    String chartVersion1 = "chartVersionHere";
     ChartVersion version1 = new ChartVersion(chartName, chartVersion1);
 
     String chartVersion2 = "chartVersionHereToo";
@@ -69,7 +69,7 @@ class ChartVersionDaoTest extends BaseDaoTest {
     ChartVersion version2_1 = new ChartVersion(chartName2, chartVersion2_1);
     ChartVersion version2_2 = new ChartVersion(chartName2, chartVersion2_2);
 
-    String chartName3 = "chartVersionHereAgain";
+    String chartName3 = "chart-name";
     String chartVersion3_1 = "chartVersionHereFive";
     String chartVersion3_2 = "chartVersionHereSix";
     ChartVersion version3_1 = new ChartVersion(chartName3, chartVersion3_1);

--- a/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
+++ b/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.common.exception.InconsistentFieldsException;
 import org.junit.jupiter.api.Test;
 
-public class ChartVersionValidationTest {
+class ChartVersionValidationTest {
 
   @Test
   void testChartNameValidation() {

--- a/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
+++ b/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
@@ -1,0 +1,85 @@
+package bio.terra.appmanager.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.common.exception.InconsistentFieldsException;
+import org.junit.jupiter.api.Test;
+
+public class ChartVersionValidationTest {
+
+  @Test
+  void testChartNameValidation() {
+    String controlChartVersion = "chartVersion";
+    String goodChartName1 = "good";
+    String goodChartName2 = "also-good";
+    String goodChartName3 = "numbers1";
+
+    String badChartName1 = "upperCase";
+    String badChartName2 = "specialchar$";
+    String badChartName3 = "tooooooooooooooooooolooooooooooooooooooooooooooooooooooong";
+
+    assertDoesNotThrow(() -> new ChartVersion(goodChartName1, controlChartVersion));
+    assertDoesNotThrow(() -> new ChartVersion(goodChartName2, controlChartVersion));
+    assertDoesNotThrow(() -> new ChartVersion(goodChartName3, controlChartVersion));
+    Exception ex1 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(badChartName1, controlChartVersion));
+    assertTrue(ex1.getMessage().contains(getPartialChartNameExceptionMessage(badChartName1)));
+    Exception ex2 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(badChartName2, controlChartVersion));
+    assertTrue(ex2.getMessage().contains(getPartialChartNameExceptionMessage(badChartName2)));
+    Exception ex3 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(badChartName3, controlChartVersion));
+    assertTrue(ex3.getMessage().contains(getPartialChartNameExceptionMessage(badChartName3)));
+  }
+
+  @Test
+  void testChartVersionValidation() {
+    String controlChartName = "chart-name";
+    String goodChartVersion1 = "good";
+    String goodChartVersion2 = "alsoGood";
+
+    String badChartVersion1 = "Uppercase";
+    String badChartVersion2 = "numbers1";
+    String badChartVersion3 = "specialchar$";
+    String badChartVersion4 = "dash-es";
+
+    assertDoesNotThrow(() -> new ChartVersion(controlChartName, goodChartVersion1));
+    assertDoesNotThrow(() -> new ChartVersion(controlChartName, goodChartVersion2));
+    Exception ex1 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion1));
+    assertTrue(ex1.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion1)));
+    Exception ex2 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion2));
+    assertTrue(ex2.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion2)));
+    Exception ex3 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion3));
+    assertTrue(ex3.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion3)));
+    Exception ex4 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion4));
+    assertTrue(ex4.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion4)));
+  }
+
+  private String getPartialChartNameExceptionMessage(String chartName) {
+    return "Chart name " + chartName + " is invalid";
+  }
+
+  private String getPartialChartVersionExceptionMessage(String chartVersion) {
+    return "Chart version " + chartVersion + " is invalid";
+  }
+}

--- a/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
+++ b/service/src/test/java/bio/terra/appmanager/model/ChartVersionValidationTest.java
@@ -46,10 +46,12 @@ public class ChartVersionValidationTest {
     String goodChartVersion1 = "good";
     String goodChartVersion2 = "alsoGood";
 
-    String badChartVersion1 = "Uppercase";
+    String badChartVersion1 = "UpperCaseStart";
     String badChartVersion2 = "numbers1";
     String badChartVersion3 = "specialchar$";
     String badChartVersion4 = "dash-es";
+    String badChartVersion5 = "tooooooooooooooooooolooooooooooooooooooooooooooooooooooong";
+    String badChartVersion6 = "twoUPpercase";
 
     assertDoesNotThrow(() -> new ChartVersion(controlChartName, goodChartVersion1));
     assertDoesNotThrow(() -> new ChartVersion(controlChartName, goodChartVersion2));
@@ -73,6 +75,16 @@ public class ChartVersionValidationTest {
             InconsistentFieldsException.class,
             () -> new ChartVersion(controlChartName, badChartVersion4));
     assertTrue(ex4.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion4)));
+    Exception ex5 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion5));
+    assertTrue(ex5.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion5)));
+    Exception ex6 =
+        assertThrows(
+            InconsistentFieldsException.class,
+            () -> new ChartVersion(controlChartName, badChartVersion6));
+    assertTrue(ex6.getMessage().contains(getPartialChartVersionExceptionMessage(badChartVersion6)));
   }
 
   private String getPartialChartNameExceptionMessage(String chartName) {

--- a/service/src/test/java/bio/terra/appmanager/service/ChartServiceTest.java
+++ b/service/src/test/java/bio/terra/appmanager/service/ChartServiceTest.java
@@ -28,7 +28,7 @@ class ChartServiceTest extends BaseSpringBootTest {
   @Test
   void testCreateChartVersion_singleElement() {
     String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
+    String chartVersion1_1 = "chartVersionHere";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
 
     ArgumentCaptor<ChartVersion> argument = ArgumentCaptor.forClass(ChartVersion.class);
@@ -43,8 +43,8 @@ class ChartServiceTest extends BaseSpringBootTest {
   @Test
   void testCreateChartVersion_multipleElement() {
     String chartName1 = "chart-name-here";
-    String chartVersion1_1 = "chart-version-here-1";
-    String chartVersion1_2 = "chart-version-here-too";
+    String chartVersion1_1 = "chartVersionHereOne";
+    String chartVersion1_2 = "chartVersionHereToo";
     ChartVersion version1_1 = new ChartVersion(chartName1, chartVersion1_1);
     ChartVersion version1_2 = new ChartVersion(chartName1, chartVersion1_2);
 


### PR DESCRIPTION
This PR implements validation in the model itself, as is described in this article about validation of java `record` classes in their constructor: https://www.baeldung.com/java-record-keyword#constructors

Another approach I investigated was use of swagger's `pattern` keyword in thhe openapi specification, but this does not properly cascade and enforce validation. See: https://github.com/swagger-api/swagger-codegen/issues/7980

I also played around with the `@Valid` keyword, but it did not seem to behave properly for our use case. 

Open to feedback about this approach.

