### PR TITLE
[AN-4] update swagger-ui to 5.17.14 and use blessed AppSec distroless image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # @team-members will be requested for review when someone
 # opens a pull request.
-* @DataBiosphere/broad-interactive-analysis
+* @DataBiosphere/dsp-analysis

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.srcclr.gradle'
     id 'org.sonarqube'
 
-    id 'com.gorylenko.gradle-git-properties' version '2.3.1'
+    id 'com.gorylenko.gradle-git-properties' version '2.4.2'
     id 'org.liquibase.gradle' version '2.2.2'
     id "io.sentry.jvm.gradle" version "4.6.0"
 }

--- a/service/generators.gradle
+++ b/service/generators.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations'
-    runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.9.0'
+    runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.17.14'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
 
     // Versioned by Spring:

--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -22,7 +22,7 @@ tasks.register('extractProfilerAgent', Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-12-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
<!-- Welcome to your Terra-app-manager pull request! -->
<!-- Contributor guidelines found in CONTRIBUTING.md -->

__Jira tickets__: 
- https://broadworkbench.atlassian.net/browse/AN-4
- https://broadworkbench.atlassian.net/browse/AN-2

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Update swagger UI dist from 4.9.0 to 5.17.14
- Update image from 17-distroless (debian 11) to 17-12-distroless (debian 12)

### Why

- Includes fix for dompurify sub dependency
- Distroless Debian 12 fixes a critical security issue


## Checklist

- [ ] Thorough tests have been added and/or updated for this change
- [ ] Documentation has been updated for this change <!-- (if applicable) -->
- [ ] This change has been validated in a BEE and/or locally <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
